### PR TITLE
fix: check if package name is enabled

### DIFF
--- a/app/src/main/java/me/saket/dank/ui/UrlRouter.java
+++ b/app/src/main/java/me/saket/dank/ui/UrlRouter.java
@@ -127,7 +127,7 @@ public class UrlRouter {
           // Smart linking.
           if (defaultWebBrowser == DefaultWebBrowser.DANK_INTERNAL_BROWSER) {
             String packageNameForDeepLink = findAllowedPackageNameForDeepLink(url);
-            if (packageNameForDeepLink != null && isPackageNameInstalled(context, packageNameForDeepLink)) {
+            if (packageNameForDeepLink != null && isPackageNameInstalledAndEnabled(context, packageNameForDeepLink)) {
               return Intents.createForOpeningUrl(url).setPackage(packageNameForDeepLink);
             }
           }
@@ -228,12 +228,10 @@ public class UrlRouter {
     }
   }
 
-  public static boolean isPackageNameInstalled(Context context, String packageName) {
+  public static boolean isPackageNameInstalledAndEnabled(Context context, String packageName) {
     PackageManager packageManager = context.getPackageManager();
     try {
-      packageManager.getPackageInfo(packageName, PackageManager.GET_ACTIVITIES);
-      return true;
-
+      return packageManager.getApplicationInfo(packageName, 0).enabled;
     } catch (PackageManager.NameNotFoundException ignored) {
       return false;
     }


### PR DESCRIPTION
Checking only if the app is installed is not sufficient. Sometimes it can be disabled.
In such a case, Intent won't be fired successfully.

Steps to reproduce:
1. Diable Youtube app
2. Go to /r/videos and try opening any of the videos.

Expected: Video opens in YouTube

Actual: Error toast

This fix opens the URL as a regular URL if app is disabled